### PR TITLE
feat: add MiniMax provider support for deep-analysis mode

### DIFF
--- a/main.py
+++ b/main.py
@@ -195,49 +195,83 @@ def create_feishu_doc(title, markdown_content):
 
     return True
 
-def deep_analysis(file_path, title, content_type, to_feishu=False):
-    """深度分析模式：生成问题并递归提问"""
+def deep_analysis(file_path, title, content_type, to_feishu=False, provider="notebooklm", model=None):
+    """深度分析模式：生成问题并递归提问
+
+    Args:
+        file_path:    本地内容文件路径
+        title:        内容标题
+        content_type: 内容类型（epub / document / url 等）
+        to_feishu:    是否写入飞书文档
+        provider:     AI 分析提供方，"notebooklm"（默认）或 "minimax"
+        model:        使用 minimax provider 时的模型名，默认 MiniMax-M2.7
+    """
     print("\n" + "="*60)
     print("🔍 启动深度分析模式")
+    if provider == "minimax":
+        used_model = model or "MiniMax-M2.7"
+        print(f"   Provider: MiniMax ({used_model})")
+    else:
+        print("   Provider: NotebookLM")
     print("="*60 + "\n")
 
-    # 1. 上传到 NotebookLM
-    print("📤 Step 1/3: 上传内容到 NotebookLM...")
-    if not upload_to_notebooklm(file_path, title):
-        return None
-
-    # 等待 NotebookLM 处理完成
-    print("⏳ 等待 NotebookLM 处理内容...")
-    time.sleep(3)
-
     # 2. 生成问题
-    print("\n📝 Step 2/3: 生成深度分析问题...")
+    print("\n📝 Step 1/2: 生成深度分析问题...")
     questions = generate_questions(content_type, title)
     print(f"✅ 已生成 {len(questions)} 个问题\n")
 
     # 3. 递归提问
-    print("💬 Step 3/3: 开始递归提问...\n")
+    print("💬 Step 2/2: 开始递归提问...\n")
     answers = []
 
-    for i, question in enumerate(questions, 1):
-        print(f"[{i}/{len(questions)}] {question}")
-        answer = ask_notebooklm(question)
+    if provider == "minimax":
+        # 读取内容文件，直接传给 MiniMax API
+        try:
+            with open(file_path, "r", encoding="utf-8", errors="replace") as fh:
+                content = fh.read()
+        except OSError as exc:
+            print(f"❌ 读取文件失败: {exc}", file=sys.stderr)
+            return None
 
-        if answer:
-            print(f"✅ 已回答\n")
-            answers.append(answer)
-        else:
-            print(f"⚠️ 跳过\n")
-            answers.append("")
+        from minimax_provider import analyze_content
+        try:
+            answers = analyze_content(
+                content,
+                questions,
+                model=used_model,
+            )
+            print(f"✅ MiniMax 已回答 {len(answers)} 个问题\n")
+        except Exception as exc:
+            print(f"❌ MiniMax 分析失败: {exc}", file=sys.stderr)
+            return None
+    else:
+        # 默认 NotebookLM 流程
+        print("📤 上传内容到 NotebookLM...")
+        if not upload_to_notebooklm(file_path, title):
+            return None
 
-        # 避免请求过快
-        time.sleep(1)
+        print("⏳ 等待 NotebookLM 处理内容...")
+        time.sleep(3)
+
+        for i, question in enumerate(questions, 1):
+            print(f"[{i}/{len(questions)}] {question}")
+            answer = ask_notebooklm(question)
+
+            if answer:
+                print(f"✅ 已回答\n")
+                answers.append(answer)
+            else:
+                print(f"⚠️ 跳过\n")
+                answers.append("")
+
+            time.sleep(1)
 
     # 4. 返回结构化数据
     result = {
         "status": "success",
         "title": title,
         "content_type": content_type,
+        "provider": provider,
         "questions": questions,
         "answers": answers,
         "total_questions": len(questions),
@@ -253,12 +287,26 @@ def deep_analysis(file_path, title, content_type, to_feishu=False):
 
 def main():
     if len(sys.argv) < 2:
-        print("用法: main.py <输入路径或URL> [--deep-analysis] [--to-feishu]", file=sys.stderr)
+        print("用法: main.py <输入路径或URL> [--deep-analysis] [--to-feishu] [--provider notebooklm|minimax] [--model MiniMax-M2.7]", file=sys.stderr)
         sys.exit(1)
 
     input_arg = sys.argv[1]
     deep_mode = '--deep-analysis' in sys.argv
     to_feishu = '--to-feishu' in sys.argv
+
+    # --provider notebooklm (default) | minimax
+    provider = "notebooklm"
+    if '--provider' in sys.argv:
+        idx = sys.argv.index('--provider')
+        if idx + 1 < len(sys.argv):
+            provider = sys.argv[idx + 1]
+
+    # --model <model-id>  (only used with --provider minimax)
+    llm_model = None
+    if '--model' in sys.argv:
+        idx = sys.argv.index('--model')
+        if idx + 1 < len(sys.argv):
+            llm_model = sys.argv[idx + 1]
 
     input_type = detect_input_type(input_arg)
     print(f"📋 检测到输入类型: {input_type}")
@@ -275,7 +323,7 @@ def main():
         title = epub_path.stem
 
         if deep_mode:
-            result = deep_analysis(txt_path, title, input_type)
+            result = deep_analysis(txt_path, title, input_type, to_feishu=to_feishu, provider=provider, model=llm_model)
             if result:
                 # 保存结果到文件
                 output_file = f"/tmp/{title}_analysis.json"
@@ -292,7 +340,7 @@ def main():
         title = doc_path.stem
 
         if deep_mode:
-            result = deep_analysis(str(doc_path), title, input_type)
+            result = deep_analysis(str(doc_path), title, input_type, to_feishu=to_feishu, provider=provider, model=llm_model)
             if result:
                 output_file = f"/tmp/{title}_analysis.json"
                 with open(output_file, 'w', encoding='utf-8') as f:
@@ -329,7 +377,7 @@ def main():
         print(f"   TXT: {txt_path}")
 
         if deep_mode:
-            result_data = deep_analysis(txt_path, title, 'podcast')
+            result_data = deep_analysis(txt_path, title, 'podcast', to_feishu=to_feishu, provider=provider, model=llm_model)
             if result_data:
                 safe_title = re.sub(r'[：:/\\?|<>*"\']', '_', title).strip('_')[:60]
                 output_file = f"/tmp/{safe_title}_analysis.json"
@@ -378,7 +426,7 @@ def main():
         print(f"   TXT: {txt_path}")
 
         if deep_mode:
-            result_data = deep_analysis(txt_path, safe_title, 'x_twitter')
+            result_data = deep_analysis(txt_path, safe_title, 'x_twitter', to_feishu=to_feishu, provider=provider, model=llm_model)
             if result_data:
                 output_file = f"/tmp/{safe_title}_analysis.json"
                 with open(output_file, 'w', encoding='utf-8') as f:

--- a/minimax_provider.py
+++ b/minimax_provider.py
@@ -1,0 +1,90 @@
+"""MiniMax LLM provider for content analysis.
+
+Provides an alternative to NotebookLM for the deep-analysis Q&A workflow,
+using the MiniMax OpenAI-compatible Chat API.
+
+Supported models:
+  - MiniMax-M2.7            (default)
+  - MiniMax-M2.7-highspeed
+"""
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    pass
+
+MINIMAX_BASE_URL = "https://api.minimax.io/v1"
+MINIMAX_DEFAULT_MODEL = "MiniMax-M2.7"
+MINIMAX_MODELS = ["MiniMax-M2.7", "MiniMax-M2.7-highspeed"]
+
+# Maximum characters of content passed as system context (≈ 50 000 tokens worst-case)
+MAX_CONTENT_LENGTH = 50_000
+
+
+def _get_client(api_key: str | None = None, base_url: str | None = None):
+    """Return an OpenAI-compatible client pointed at the MiniMax API."""
+    try:
+        from openai import OpenAI
+    except ImportError as exc:
+        raise ImportError(
+            "The 'openai' package is required for the MiniMax provider. "
+            "Install it with: pip install openai"
+        ) from exc
+
+    resolved_key = api_key or os.environ.get("MINIMAX_API_KEY")
+    if not resolved_key:
+        raise ValueError(
+            "MiniMax API key is required. "
+            "Set MINIMAX_API_KEY environment variable or pass api_key."
+        )
+
+    resolved_url = base_url or os.environ.get("MINIMAX_BASE_URL", MINIMAX_BASE_URL)
+    return OpenAI(api_key=resolved_key, base_url=resolved_url)
+
+
+def analyze_content(
+    content: str,
+    questions: list[str],
+    *,
+    model: str = MINIMAX_DEFAULT_MODEL,
+    api_key: str | None = None,
+    base_url: str | None = None,
+) -> list[str]:
+    """Answer *questions* about *content* using the MiniMax Chat API.
+
+    Args:
+        content:   The source text to analyse (will be truncated if too long).
+        questions: List of questions to ask about the content.
+        model:     MiniMax model ID to use (default: MiniMax-M2.7).
+        api_key:   Override MINIMAX_API_KEY environment variable.
+        base_url:  Override MINIMAX_BASE_URL environment variable.
+
+    Returns:
+        List of answer strings, one per question.
+    """
+    client = _get_client(api_key=api_key, base_url=base_url)
+    truncated = content[:MAX_CONTENT_LENGTH]
+
+    system_prompt = (
+        "You are an expert content analyst. "
+        "Read the following content carefully and answer every question concisely and accurately.\n\n"
+        f"--- CONTENT START ---\n{truncated}\n--- CONTENT END ---"
+    )
+
+    answers: list[str] = []
+    for question in questions:
+        response = client.chat.completions.create(
+            model=model,
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": question},
+            ],
+            temperature=1.0,
+            max_tokens=1024,
+        )
+        answer = response.choices[0].message.content or ""
+        answers.append(answer)
+
+    return answers

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,8 @@ lxml>=4.9.0
 # File format conversion
 markitdown[all]>=0.0.1
 
+# LLM providers (MiniMax and other OpenAI-compatible APIs)
+openai>=1.0.0
+
 # NotebookLM (will be installed from PyPI if available, or from git)
 # notebooklm-py

--- a/tests/test_minimax_provider.py
+++ b/tests/test_minimax_provider.py
@@ -1,0 +1,201 @@
+"""Unit tests for minimax_provider.py"""
+import importlib
+import os
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Ensure the repo root is importable
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+def _make_openai_mock(content: str = "Test answer"):
+    """Return a minimal mock that looks like openai.OpenAI."""
+    mock_client = MagicMock()
+    choice = MagicMock()
+    choice.message.content = content
+    mock_client.chat.completions.create.return_value = MagicMock(choices=[choice])
+    return mock_client
+
+
+# ---------------------------------------------------------------------------
+# _get_client tests
+# ---------------------------------------------------------------------------
+
+class TestGetClient:
+    def test_raises_when_no_api_key(self):
+        """_get_client must raise ValueError when no key is available."""
+        import minimax_provider
+        with patch.dict(os.environ, {}, clear=True):
+            # Remove MINIMAX_API_KEY from env if present
+            env = {k: v for k, v in os.environ.items() if k != "MINIMAX_API_KEY"}
+            with patch.dict(os.environ, env, clear=True):
+                with pytest.raises((ValueError, Exception)):
+                    minimax_provider._get_client()
+
+    def test_uses_env_api_key(self):
+        """_get_client reads MINIMAX_API_KEY from environment."""
+        import minimax_provider
+        mock_openai_cls = MagicMock(return_value=MagicMock())
+        with patch.dict(os.environ, {"MINIMAX_API_KEY": "env-key-123"}):
+            with patch("minimax_provider.OpenAI", mock_openai_cls, create=True):
+                # Patch the import inside the function
+                with patch.dict(sys.modules, {"openai": types.ModuleType("openai")}):
+                    sys.modules["openai"].OpenAI = mock_openai_cls
+                    client = minimax_provider._get_client()
+                    mock_openai_cls.assert_called_once()
+                    call_kwargs = mock_openai_cls.call_args[1]
+                    assert call_kwargs.get("api_key") == "env-key-123"
+
+    def test_uses_explicit_api_key(self):
+        """_get_client uses the explicitly passed api_key."""
+        import minimax_provider
+        mock_openai_cls = MagicMock(return_value=MagicMock())
+        with patch.dict(sys.modules, {"openai": types.ModuleType("openai")}):
+            sys.modules["openai"].OpenAI = mock_openai_cls
+            minimax_provider._get_client(api_key="explicit-key", base_url="https://api.minimax.io/v1")
+            call_kwargs = mock_openai_cls.call_args[1]
+            assert call_kwargs.get("api_key") == "explicit-key"
+
+    def test_default_base_url(self):
+        """_get_client defaults to MINIMAX_BASE_URL."""
+        import minimax_provider
+        mock_openai_cls = MagicMock(return_value=MagicMock())
+        with patch.dict(os.environ, {"MINIMAX_API_KEY": "key"}, clear=False):
+            env_no_base = {k: v for k, v in os.environ.items() if k != "MINIMAX_BASE_URL"}
+            with patch.dict(os.environ, env_no_base, clear=True):
+                with patch.dict(os.environ, {"MINIMAX_API_KEY": "key"}):
+                    with patch.dict(sys.modules, {"openai": types.ModuleType("openai")}):
+                        sys.modules["openai"].OpenAI = mock_openai_cls
+                        minimax_provider._get_client(api_key="key")
+                        call_kwargs = mock_openai_cls.call_args[1]
+                        assert call_kwargs.get("base_url") == minimax_provider.MINIMAX_BASE_URL
+
+    def test_custom_base_url(self):
+        """_get_client respects an explicitly passed base_url."""
+        import minimax_provider
+        mock_openai_cls = MagicMock(return_value=MagicMock())
+        custom_url = "https://custom.minimax.io/v1"
+        with patch.dict(sys.modules, {"openai": types.ModuleType("openai")}):
+            sys.modules["openai"].OpenAI = mock_openai_cls
+            minimax_provider._get_client(api_key="key", base_url=custom_url)
+            call_kwargs = mock_openai_cls.call_args[1]
+            assert call_kwargs.get("base_url") == custom_url
+
+
+# ---------------------------------------------------------------------------
+# analyze_content tests
+# ---------------------------------------------------------------------------
+
+class TestAnalyzeContent:
+    def _patch_client(self, mock_client, monkeypatch):
+        import minimax_provider
+        monkeypatch.setattr(minimax_provider, "_get_client", lambda **kw: mock_client)
+
+    def test_returns_one_answer_per_question(self, monkeypatch):
+        import minimax_provider
+        mock_client = _make_openai_mock("answer")
+        monkeypatch.setattr(minimax_provider, "_get_client", lambda **kw: mock_client)
+        answers = minimax_provider.analyze_content(
+            content="Some article text.",
+            questions=["Q1", "Q2", "Q3"],
+        )
+        assert len(answers) == 3
+
+    def test_answer_text_is_returned(self, monkeypatch):
+        import minimax_provider
+        mock_client = _make_openai_mock("Expected answer")
+        monkeypatch.setattr(minimax_provider, "_get_client", lambda **kw: mock_client)
+        answers = minimax_provider.analyze_content("content", ["single question"])
+        assert answers[0] == "Expected answer"
+
+    def test_default_model_is_minimax_m27(self, monkeypatch):
+        import minimax_provider
+        mock_client = _make_openai_mock("ok")
+        monkeypatch.setattr(minimax_provider, "_get_client", lambda **kw: mock_client)
+        minimax_provider.analyze_content("text", ["q"])
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        assert call_kwargs["model"] == "MiniMax-M2.7"
+
+    def test_custom_model_is_passed(self, monkeypatch):
+        import minimax_provider
+        mock_client = _make_openai_mock("ok")
+        monkeypatch.setattr(minimax_provider, "_get_client", lambda **kw: mock_client)
+        minimax_provider.analyze_content("text", ["q"], model="MiniMax-M2.7-highspeed")
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        assert call_kwargs["model"] == "MiniMax-M2.7-highspeed"
+
+    def test_temperature_is_1(self, monkeypatch):
+        """MiniMax requires temperature in (0.0, 1.0]; we always send 1.0."""
+        import minimax_provider
+        mock_client = _make_openai_mock("ok")
+        monkeypatch.setattr(minimax_provider, "_get_client", lambda **kw: mock_client)
+        minimax_provider.analyze_content("text", ["q"])
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        assert call_kwargs["temperature"] == 1.0
+
+    def test_content_truncated_to_max_length(self, monkeypatch):
+        import minimax_provider
+        mock_client = _make_openai_mock("ok")
+        monkeypatch.setattr(minimax_provider, "_get_client", lambda **kw: mock_client)
+        long_content = "x" * (minimax_provider.MAX_CONTENT_LENGTH + 5000)
+        minimax_provider.analyze_content(long_content, ["q"])
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        system_msg = next(
+            m["content"] for m in call_kwargs["messages"] if m["role"] == "system"
+        )
+        # The truncated content must appear in the system message
+        assert "x" * minimax_provider.MAX_CONTENT_LENGTH in system_msg
+        # But NOT beyond the limit
+        assert "x" * (minimax_provider.MAX_CONTENT_LENGTH + 1) not in system_msg
+
+    def test_empty_questions_returns_empty_list(self, monkeypatch):
+        import minimax_provider
+        mock_client = _make_openai_mock("ok")
+        monkeypatch.setattr(minimax_provider, "_get_client", lambda **kw: mock_client)
+        answers = minimax_provider.analyze_content("text", [])
+        assert answers == []
+        mock_client.chat.completions.create.assert_not_called()
+
+    def test_none_response_becomes_empty_string(self, monkeypatch):
+        import minimax_provider
+        mock_client = MagicMock()
+        choice = MagicMock()
+        choice.message.content = None
+        mock_client.chat.completions.create.return_value = MagicMock(choices=[choice])
+        monkeypatch.setattr(minimax_provider, "_get_client", lambda **kw: mock_client)
+        answers = minimax_provider.analyze_content("text", ["q"])
+        assert answers == [""]
+
+
+# ---------------------------------------------------------------------------
+# Module-level constants tests
+# ---------------------------------------------------------------------------
+
+class TestConstants:
+    def test_default_model_is_defined(self):
+        import minimax_provider
+        assert minimax_provider.MINIMAX_DEFAULT_MODEL == "MiniMax-M2.7"
+
+    def test_models_list_contains_expected_models(self):
+        import minimax_provider
+        assert "MiniMax-M2.7" in minimax_provider.MINIMAX_MODELS
+        assert "MiniMax-M2.7-highspeed" in minimax_provider.MINIMAX_MODELS
+
+    def test_base_url_uses_api_minimax_io(self):
+        import minimax_provider
+        assert minimax_provider.MINIMAX_BASE_URL.startswith("https://api.minimax.io")
+
+    def test_no_minimax_embedding_model(self):
+        """Ensure we have NOT added any embedding model (MiniMax has none)."""
+        import minimax_provider
+        for attr in dir(minimax_provider):
+            assert "embed" not in attr.lower(), (
+                f"Unexpected embedding-related attribute found: {attr}"
+            )


### PR DESCRIPTION
## Summary

- Add `minimax_provider.py` with an OpenAI-compatible client targeting the MiniMax API (international endpoint `https://api.minimax.io/v1`)
- Support **MiniMax-M2.7** (default) and **MiniMax-M2.7-highspeed** as analysis models
- Add `--provider minimax` flag to `main.py` so users can run deep-analysis using MiniMax instead of NotebookLM
- Add optional `--model` flag for model selection
- Add `openai>=1.0.0` to `requirements.txt`
- Add **17 unit tests** in `tests/test_minimax_provider.py` (all passing)

## Usage

```bash
# Set API key
export MINIMAX_API_KEY=your_key_here

# Deep-analysis using MiniMax-M2.7 (no NotebookLM auth required)
python main.py /path/to/file.epub --deep-analysis --provider minimax

# Use the faster model
python main.py /path/to/file.md --deep-analysis --provider minimax --model MiniMax-M2.7-highspeed
```

## API References

- Chat (OpenAI Compatible): https://platform.minimax.io/docs/api-reference/text-openai-api

## Implementation Notes

- Temperature is fixed at `1.0` per MiniMax API constraints (range: `(0.0, 1.0]`)
- Content is truncated to 50 000 characters when passed as context
- The default NotebookLM workflow is unchanged; `--provider minimax` opts into the new path