### PR TITLE
fix: Windows GBK 编码导致 check_env.py Unicode 报错

### DIFF
--- a/check_env.py
+++ b/check_env.py
@@ -8,6 +8,10 @@ import os
 import json
 from pathlib import Path
 
+# Windows GBK 编码无法输出 emoji，强制使用 UTF-8
+if sys.platform == 'win32':
+    sys.stdout.reconfigure(encoding='utf-8')
+
 # 颜色输出
 RED = '\033[0;31m'
 GREEN = '\033[0;32m'
@@ -61,7 +65,7 @@ def check_command(cmd):
         try:
             result = subprocess.run([cmd, "--version"],
                                   capture_output=True,
-                                  text=True,
+                                  encoding='utf-8',
                                   timeout=5)
             version = result.stdout.split('\n')[0] if result.stdout else "unknown"
             print_status("ok", f"{cmd} 已安装 ({version})")
@@ -113,7 +117,7 @@ def check_notebooklm_auth():
     try:
         result = subprocess.run(["notebooklm", "list"],
                               capture_output=True,
-                              text=True,
+                              encoding='utf-8',
                               timeout=10)
 
         if result.returncode == 0:


### PR DESCRIPTION
## 问题

在 Windows 中文环境下，`python check_env.py` 直接崩溃：

1. **`UnicodeEncodeError`** — `print_status()` 输出 ✅/❌/⚠️/ℹ️ emoji 时，Windows 终端默认 GBK 编码无法编码这些 Unicode 字符，脚本第一行就报错退出。

2. **`UnicodeDecodeError`（后台线程）** — `subprocess.run(text=True)` 默认使用系统编码 (GBK) 解码子进程输出。`notebooklm --version`、`git --version` 等命令的输出中可能包含非 GBK 字符，导致后台 reader 线程爆 `UnicodeDecodeError`。

## 修复

- `sys.stdout.reconfigure(encoding='utf-8')` — Windows 平台强制 stdout 使用 UTF-8（3 行）
- 两处 `subprocess.run(text=True)` → `encoding='utf-8'` — 显式指定子进程输出编码

## 验证

修复后 `python check_env.py` 在 Windows 11 (Python 3.13, GBK 默认编码) 下全部 13 项检查通过，无任何编码错误。